### PR TITLE
Lock CURRENT file while db is open

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -783,6 +783,7 @@ VersionSet::VersionSet(const std::string& dbname,
       icmp_(*cmp),
       next_file_number_(2),
       manifest_file_number_(0),  // Filled by Recover()
+      current_lock_(NULL),
       last_sequence_(0),
       log_number_(0),
       prev_log_number_(0),
@@ -798,6 +799,9 @@ VersionSet::~VersionSet() {
   assert(dummy_versions_.next_ == &dummy_versions_);  // List must be empty
   delete descriptor_log_;
   delete descriptor_file_;
+  if (current_lock_ != NULL) {
+    env_->UnlockFile(current_lock_);
+  }
 }
 
 void VersionSet::AppendVersion(Version* v) {
@@ -844,6 +848,7 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
   // a temporary file that contains a snapshot of the current version.
   std::string new_manifest_file;
   Status s;
+  Status ls;
   if (descriptor_log_ == NULL) {
     // No reason to unlock *mu here since we only hit this path in the
     // first call to LogAndApply (when opening the database).
@@ -877,7 +882,14 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
     // If we just created a new descriptor file, install it by writing a
     // new CURRENT file that points to it.
     if (s.ok() && !new_manifest_file.empty()) {
+      if (current_lock_ != NULL) {
+        env_->UnlockFile(current_lock_);
+        current_lock_ = NULL;
+      }
       s = SetCurrentFile(env_, dbname_, manifest_file_number_);
+      if (s.ok()) {
+        ls = env_->LockFile(CurrentFileName(dbname_), &current_lock_);
+      }
     }
 
     mu->Lock();
@@ -899,6 +911,9 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
     }
   }
 
+  if (!ls.ok()){
+      return ls;
+  }
   return s;
 }
 
@@ -916,6 +931,14 @@ Status VersionSet::Recover(bool *save_manifest) {
   if (!s.ok()) {
     return s;
   }
+  
+  if (current_lock_ == NULL) {
+    s = env_->LockFile(CurrentFileName(dbname_), &current_lock_);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  
   const size_t maxSize = current.size();
   size_t size = 0;
   // find the first non-printable character (eg null, carriage return or newline)

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include "db/dbformat.h"
 #include "db/version_edit.h"
+#include "leveldb/env.h"
 #include "port/port.h"
 #include "port/thread_annotations.h"
 
@@ -301,6 +302,7 @@ class VersionSet {
   const InternalKeyComparator icmp_;
   uint64_t next_file_number_;
   uint64_t manifest_file_number_;
+  FileLock* current_lock_;
   uint64_t last_sequence_;
   uint64_t log_number_;
   uint64_t prev_log_number_;  // 0 or backing store for memtable being compacted

--- a/util/env_win.cc
+++ b/util/env_win.cc
@@ -315,7 +315,7 @@ namespace leveldb {
 					if (_fileSizeLow > 0 || _fileSizeHigh > 0)
 					{
                         OVERLAPPED overlapped = { };
-						if (!::LockFileEx(_file, 0, 0, _fileSizeLow, _fileSizeHigh, &overlapped))
+						if (!::LockFileEx(_file, 3, 0, _fileSizeLow, _fileSizeHigh, &overlapped))
 						{
 							Status s = GetLastWindowsError(fname);
 							throw IOException(s.ToString().c_str());
@@ -333,10 +333,13 @@ namespace leveldb {
 				if (_file != INVALID_HANDLE_VALUE)
 				{
 					if (_fileSizeLow > 0 || _fileSizeHigh > 0)
-						if (!::UnlockFileEx(_file, 0, _fileSizeLow, _fileSizeHigh, NULL))
+					{
+						OVERLAPPED overlapped = { };
+						if (!::UnlockFileEx(_file, 0, _fileSizeLow, _fileSizeHigh, &overlapped))
 						{
 							Status s = GetLastWindowsError(_fname);
 						}
+					}
 					CloseFile(_fname, _file);
 				}
 			}


### PR DESCRIPTION
The leveldb implementation used by Minecraft does not seem to care about the LOCK file and will just open the database even if we have it open. This can cause corruption if we both continue writing to it.

The only way I can find to stop the game doing this is by locking the CURRENT file in exclusive mode.
When modifying the CURRENT file we need to unlock it before and re-lock it after.